### PR TITLE
Fix VBA compile/runtime issues and deduplicate logger logic

### DIFF
--- a/frameworks/vba-omni-logger/src/COmniLogger.cls
+++ b/frameworks/vba-omni-logger/src/COmniLogger.cls
@@ -416,7 +416,7 @@ Public Sub log(ParamArray data() As Variant)
             incr i
         End If
         
-        If UBound(data) > 1 Then
+        If UBound(data) > 0 Then
             For Each vArg In data
                 Range(mLogTarget).Cells(mLogPosition, i) = vArg
                 incr i
@@ -482,7 +482,7 @@ Public Sub logArray(data As Variant)
             incr i
         End If
         
-        If UBound(data) > 1 Then
+        If UBound(data) > 0 Then
             For Each vArg In data
                 Range(mLogTarget).Cells(mLogPosition, i) = vArg
                 incr i

--- a/frameworks/vba-omni-logger/src/COmniLogger.cls
+++ b/frameworks/vba-omni-logger/src/COmniLogger.cls
@@ -384,21 +384,10 @@ End Sub
 ''' --------------------------
 ''' </summary>
 Public Sub log(ParamArray data() As Variant)
-    Dim i As Integer
     Dim toPrint As String
-    Dim vArg As Variant
    
     If mLogTargetType <> logRange Then
-        If mWithTimestamp Then
-            toPrint = Format(Now(), mTimestampFormat)
-        Else
-            toPrint = ""
-        End If
-        
-        For Each vArg In data
-            toPrint = toPrint & IIf(toPrint = "", vArg, mLogDelimiter & vArg)
-        Next vArg
-    
+        toPrint = composeLine(data)
     End If
 
     Select Case mLogTargetType
@@ -409,28 +398,7 @@ Public Sub log(ParamArray data() As Variant)
         Print #mFileID, toPrint
 
     Case logRange
-        i = 1
-        If mWithTimestamp Then
-            Range(mLogTarget).Cells(mLogPosition, i).NumberFormat = mTimestampFormat
-            Range(mLogTarget).Cells(mLogPosition, i) = Format(Now(), mTimestampFormat)
-            incr i
-        End If
-        
-        If UBound(data) > 0 Then
-            For Each vArg In data
-                Range(mLogTarget).Cells(mLogPosition, i) = vArg
-                incr i
-            Next vArg
-        Else
-            Dim dat
-            dat = Split(data(0), mLogDelimiter)
-            For Each vArg In dat
-                Range(mLogTarget).Cells(mLogPosition, i) = vArg
-                incr i
-            Next vArg
-        
-        End If
-        incr mLogPosition
+        writeValuesToRange data
     
     Case Else
     
@@ -450,21 +418,10 @@ End Sub
 ''' --------------------------
 ''' </summary>
 Public Sub logArray(data As Variant)
-    Dim i As Integer
     Dim toPrint As String
-    Dim vArg As Variant
    
     If mLogTargetType <> logRange Then
-        If mWithTimestamp Then
-            toPrint = Format(Now(), mTimestampFormat)
-        Else
-            toPrint = ""
-        End If
-        
-        For Each vArg In data
-            toPrint = toPrint & IIf(toPrint = "", vArg, mLogDelimiter & vArg)
-        Next vArg
-    
+        toPrint = composeLine(data)
     End If
 
     Select Case mLogTargetType
@@ -475,33 +432,58 @@ Public Sub logArray(data As Variant)
         Print #mFileID, toPrint
 
     Case logRange
-        i = 1
-        If mWithTimestamp Then
-            Range(mLogTarget).Cells(mLogPosition, i).NumberFormat = mTimestampFormat
-            Range(mLogTarget).Cells(mLogPosition, i) = Format(Now(), mTimestampFormat)
-            incr i
-        End If
-        
-        If UBound(data) > 0 Then
-            For Each vArg In data
-                Range(mLogTarget).Cells(mLogPosition, i) = vArg
-                incr i
-            Next vArg
-        Else
-            Dim dat
-            dat = Split(data(0), mLogDelimiter)
-            For Each vArg In dat
-                Range(mLogTarget).Cells(mLogPosition, i) = vArg
-                incr i
-            Next vArg
-        
-        End If
-        incr mLogPosition
+        writeValuesToRange data
     
     Case Else
     
     End Select
 
+End Sub
+
+Private Function composeLine(ByVal values As Variant) As String
+    Dim toPrint As String
+    Dim vArg As Variant
+
+    If mWithTimestamp Then
+        toPrint = Format(Now(), mTimestampFormat)
+    Else
+        toPrint = ""
+    End If
+
+    For Each vArg In values
+        toPrint = toPrint & IIf(toPrint = "", vArg, mLogDelimiter & vArg)
+    Next vArg
+
+    composeLine = toPrint
+End Function
+
+Private Sub writeValuesToRange(ByVal values As Variant)
+    Dim i As Integer
+    Dim vArg As Variant
+    Dim parsedValues As Variant
+
+    i = 1
+
+    If mWithTimestamp Then
+        Range(mLogTarget).Cells(mLogPosition, i).NumberFormat = mTimestampFormat
+        Range(mLogTarget).Cells(mLogPosition, i) = Format(Now(), mTimestampFormat)
+        incr i
+    End If
+
+    If UBound(values) > 0 Then
+        For Each vArg In values
+            Range(mLogTarget).Cells(mLogPosition, i) = vArg
+            incr i
+        Next vArg
+    Else
+        parsedValues = Split(values(0), mLogDelimiter)
+        For Each vArg In parsedValues
+            Range(mLogTarget).Cells(mLogPosition, i) = vArg
+            incr i
+        Next vArg
+    End If
+
+    incr mLogPosition
 End Sub
 
 Private Sub Class_Initialize()

--- a/frameworks/vba-omni-logger/src/MOmniLogger.bas
+++ b/frameworks/vba-omni-logger/src/MOmniLogger.bas
@@ -50,7 +50,10 @@ Private mLogger As COmniLogger
 ''' </summary>
 Public Property Get logger() As COmniLogger
     'by default logging stream is Immediate window: option = logDebug
-    If mLogger Is Nothing Then mLogger.initLog logDebug
+    If mLogger Is Nothing Then
+        Set mLogger = New COmniLogger
+        mLogger.initLog logDebug
+    End If
 
     Set logger = mLogger
 

--- a/frameworks/vba-omni-logger/src/MSupport.bas
+++ b/frameworks/vba-omni-logger/src/MSupport.bas
@@ -109,7 +109,7 @@ End Function
 ''' created 2020-08-20
 ''' --------------------------
 ''' </summary>
-Public Function lastRowInColumn(inColumn As String, Optional inSheet As Variant) As Integer
+Public Function lastRowInColumn(inColumn As String, Optional inSheet As Variant) As Long
     Dim sht
     
     If IsMissing(inSheet) Then

--- a/frameworks/vba-profiler/src/COmniLogger.cls
+++ b/frameworks/vba-profiler/src/COmniLogger.cls
@@ -165,16 +165,10 @@ Public Sub logHeader()
 End Sub
 
 Public Sub log(ParamArray data() As Variant)
-    Dim i As Integer
     Dim toPrint As String
-    Dim vArg As Variant
    
     If mLogTargetType <> logRange Then
-        toPrint = ""
-        For Each vArg In data
-            toPrint = toPrint & IIf(toPrint = "", vArg, mLogDelimiter & vArg)
-        Next vArg
-    
+        toPrint = composeLine(data)
     End If
 
     Select Case mLogTargetType
@@ -185,27 +179,48 @@ Public Sub log(ParamArray data() As Variant)
         Print #mFileID, toPrint
 
     Case logRange
-        i = 1
-        If UBound(data) > 0 Then
-            For Each vArg In data
-                Range(mLogTarget).Cells(mLogPosition, i) = vArg
-                incr i
-            Next vArg
-        Else
-            Dim dat
-            dat = Split(data(0), mLogDelimiter)
-            For Each vArg In dat
-                Range(mLogTarget).Cells(mLogPosition, i) = vArg
-                incr i
-            Next vArg
-        
-        End If
-        incr mLogPosition
+        writeValuesToRange data
     
     Case Else
     
     End Select
 
+End Sub
+
+Private Function composeLine(ByVal values As Variant) As String
+    Dim toPrint As String
+    Dim vArg As Variant
+
+    toPrint = ""
+
+    For Each vArg In values
+        toPrint = toPrint & IIf(toPrint = "", vArg, mLogDelimiter & vArg)
+    Next vArg
+
+    composeLine = toPrint
+End Function
+
+Private Sub writeValuesToRange(ByVal values As Variant)
+    Dim i As Integer
+    Dim vArg As Variant
+    Dim parsedValues As Variant
+
+    i = 1
+
+    If UBound(values) > 0 Then
+        For Each vArg In values
+            Range(mLogTarget).Cells(mLogPosition, i) = vArg
+            incr i
+        Next vArg
+    Else
+        parsedValues = Split(values(0), mLogDelimiter)
+        For Each vArg In parsedValues
+            Range(mLogTarget).Cells(mLogPosition, i) = vArg
+            incr i
+        Next vArg
+    End If
+
+    incr mLogPosition
 End Sub
 
 Private Sub Class_Initialize()

--- a/frameworks/vba-profiler/src/COmniLogger.cls
+++ b/frameworks/vba-profiler/src/COmniLogger.cls
@@ -186,7 +186,7 @@ Public Sub log(ParamArray data() As Variant)
 
     Case logRange
         i = 1
-        If UBound(data) > 1 Then
+        If UBound(data) > 0 Then
             For Each vArg In data
                 Range(mLogTarget).Cells(mLogPosition, i) = vArg
                 incr i

--- a/frameworks/vba-profiler/src/MSupport.bas
+++ b/frameworks/vba-profiler/src/MSupport.bas
@@ -49,7 +49,7 @@ End Sub
 
 Public Sub RemoveFromArray(arr As Variant, ByVal index As Integer)
     Dim i As Integer
-    If i < UBound(arr) Then
+    If index < UBound(arr) Then
         For i = index To UBound(arr) - 1
             If IsObject(arr(i + 1)) Then
                 Set arr(i) = arr(i + 1)
@@ -113,7 +113,7 @@ Public Function lastColumnInTheRow(ByVal forRow As Integer, Optional inSheet As 
     Set sht = Nothing
 End Function
 
-Public Function lastRowInColumn(inColumn As String, Optional inSheet As Variant) As Integer
+Public Function lastRowInColumn(inColumn As String, Optional inSheet As Variant) As Long
     Dim sht
     
     If IsMissing(inSheet) Then
@@ -127,7 +127,7 @@ Public Function lastRowInColumn(inColumn As String, Optional inSheet As Variant)
     
     End If
 
-    lastRowInColumn = sht.Range(inColumn & "1").Cells(65536, inColumn).End(xlUp).row
+    lastRowInColumn = sht.Cells(sht.Rows.Count, inColumn).End(xlUp).Row
 
     Set sht = Nothing
 End Function

--- a/snippets/src/MAccessors.bas
+++ b/snippets/src/MAccessors.bas
@@ -332,7 +332,7 @@ End Function
 ''' created 2020-08-20
 ''' --------------------------
 ''' </summary>
-Public Function lastRowInColumn(inColumn As String, Optional inSheet As Variant) As Integer
+Public Function lastRowInColumn(inColumn As String, Optional inSheet As Variant) As Long
     Dim sht
     
     If IsMissing(inSheet) Then
@@ -346,7 +346,7 @@ Public Function lastRowInColumn(inColumn As String, Optional inSheet As Variant)
     
     End If
 
-    lastRowInColumn = sht.Range(inColumn & "1").Cells(65536, inColumn).End(xlUp).Row
+    lastRowInColumn = sht.Cells(sht.Rows.Count, inColumn).End(xlUp).Row
 
     Set sht = Nothing
 End Function
@@ -602,6 +602,8 @@ Public Sub findDublicates(inRange As Range, idInColumns As String)
     Dim i As Long, j As Long, k As Integer
     Dim columnsID As Variant
     Dim res As String, finRes As String, curID As String, curChk As String
+    Dim inDubles As String
+    Dim curR As Long
     
     columnsID = Split(idInColumns, ",")
     inDubles = " "

--- a/snippets/src/MLogging.bas
+++ b/snippets/src/MLogging.bas
@@ -89,8 +89,8 @@ Public Sub log(ByVal action As String, Optional who As String, Optional comments
     
     enableFastCode True
         
-        If IsMissing(startCell) Then
-            If IsMissing(iStartFromCell) Then
+        If startCell Is Nothing Then
+            If iStartFromCell Is Nothing Then
                 Err.Raise 501, "MLogging.log()", "Starting cell not stated. Run initLogging() first."
             Else
                 Set startCell = iStartFromCell
@@ -100,7 +100,7 @@ Public Sub log(ByVal action As String, Optional who As String, Optional comments
         topRow = startCell.Row
         
         cloneRow topRow, , , , True
-        putValuesToRow iStartFromCell, Format(Now(), "dd.mm.yy hh:mm"), who, action, comments
+        putValuesToRow startCell, Format(Now(), "dd.mm.yy hh:mm"), who, action, comments
         Application.CutCopyMode = False
         
         '[A1].Select 'TODO Change this cell address to more suitable for you

--- a/snippets/src/MSugar.bas
+++ b/snippets/src/MSugar.bas
@@ -124,7 +124,7 @@ End Sub
 Public Sub RemoveFromArray(arr As Variant, ByVal Index As Integer)
     Dim i As Integer
     
-    If i < UBound(arr) Then
+    If Index < UBound(arr) Then
         For i = Index To UBound(arr) - 1
             If IsObject(arr(i)) Then
                 Set arr(i) = arr(i + 1)

--- a/snippets/src/MText.bas
+++ b/snippets/src/MText.bas
@@ -154,10 +154,10 @@ Public Function getTextBetween(ByVal fromText As String, ByVal startMarker As St
         endPos = InStr(startPos, fromText, endMarker, False) - 1
         If endPos < 1 Then
             getTextBetween = Mid(fromText, startPos)
-            curPos = Len(inText)
+            curPos = Len(fromText)
         
         Else
-            getTextBetween = Mid(inText, startPos, endPos - startPos + 1)
+            getTextBetween = Mid(fromText, startPos, endPos - startPos + 1)
             curPos = endPos + 1
         
         End If
@@ -286,9 +286,12 @@ Public Function parseRecords(ByVal textToParse As String, arrRecordTokens() As S
     
     Dim firstRecordToken As String
     Dim startPos As Long
-    Dim curText As String
     Dim curRec() As String
     Dim tokensCount As Integer
+    Dim recordsCount As Integer
+    Dim lenOfFirstRecordToken As Long
+    Dim endOfCurrentRecord As Long
+    Dim i As Integer
     
     
     tokensCount = UBound(arrRecordTokens)

--- a/tools/friendly_spam/src/MHelper.bas
+++ b/tools/friendly_spam/src/MHelper.bas
@@ -96,12 +96,10 @@ pastFromCell.Activate
 pastFromCell.Parent.Paste
 End Sub
 
-Public Function lastRowInColumn(inColumn As String, Optional inSheet As Variant) As Integer
+Public Function lastRowInColumn(inColumn As String, Optional inSheet As Variant) As Long
 Dim sht
 If IsMissing(inSheet) Then Set sht = ActiveSheet Else Set sht = Sheets(inSheet)
-With sht.Range(inColumn & "1")
-    lastRowInColumn = .Cells(65536, .Column).End(xlUp).Row
-End With
+lastRowInColumn = sht.Cells(sht.Rows.Count, inColumn).End(xlUp).Row
 Set sht = Nothing
 End Function
 

--- a/tools/vba_xml_comments_to_github_wiki/src/MSugar.bas
+++ b/tools/vba_xml_comments_to_github_wiki/src/MSugar.bas
@@ -124,7 +124,7 @@ End Sub
 Public Sub RemoveFromArray(arr As Variant, ByVal Index As Integer)
     Dim i As Integer
     
-    If i < UBound(arr) Then
+    If Index < UBound(arr) Then
         For i = Index To UBound(arr) - 1
             If IsObject(arr(i)) Then
                 Set arr(i) = arr(i + 1)

--- a/tools/vba_xml_comments_to_github_wiki/src/MText.bas
+++ b/tools/vba_xml_comments_to_github_wiki/src/MText.bas
@@ -155,9 +155,12 @@ Public Function parseRecords(ByVal textToParse As String, arrRecordTokens() As S
     
     Dim firstRecordToken As String
     Dim startPos As Long
-    Dim curText As String
     Dim curRec() As String
     Dim tokensCount As Integer
+    Dim recordsCount As Integer
+    Dim lenOfFirstRecordToken As Long
+    Dim endOfCurrentRecord As Long
+    Dim i As Integer
     
     
     tokensCount = UBound(arrRecordTokens)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
This PR fixes compile/runtime VBA defects discovered during audit and adds a safe, behavior-preserving logger refactor.

## Bug fixes
- Fixed compile blockers in text helpers:
  - `snippets/src/MText.bas`
  - `tools/vba_xml_comments_to_github_wiki/src/MText.bas`
- Fixed undeclared variables in:
  - `snippets/src/MAccessors.bas` (`findDublicates`)
- Fixed invalid optional object checks in:
  - `snippets/src/MLogging.bas` (`IsMissing` -> `Is Nothing`)
- Fixed lazy logger initialization in:
  - `frameworks/vba-omni-logger/src/MOmniLogger.bas`
- Fixed `ParamArray` handling for 2-argument case in:
  - `frameworks/vba-omni-logger/src/COmniLogger.cls`
  - `frameworks/vba-profiler/src/COmniLogger.cls`
- Fixed array removal condition bug in:
  - `snippets/src/MSugar.bas`
  - `tools/vba_xml_comments_to_github_wiki/src/MSugar.bas`
  - `frameworks/vba-profiler/src/MSupport.bas`
- Updated row-end helpers for modern Excel limits (`Rows.Count`) and return types to `Long` where needed:
  - `tools/friendly_spam/src/MHelper.bas`
  - `frameworks/vba-profiler/src/MSupport.bas`
  - `frameworks/vba-omni-logger/src/MSupport.bas`
  - `snippets/src/MAccessors.bas`

## Refactor (no behavior change)
- Deduplicated logging internals in both logger classes by extracting private helpers for:
  - composing non-range output lines;
  - writing values into range targets.
- Files:
  - `frameworks/vba-omni-logger/src/COmniLogger.cls`
  - `frameworks/vba-profiler/src/COmniLogger.cls`

## Validation
- Static checks confirm no remaining target patterns from the audit:
  - no `65536` fixed-row-limit usage in VBA modules;
  - no buggy `If i < UBound(arr)` conditions in affected modules;
  - no `UBound(data) > 1` in affected logger write paths;
  - no invalid `IsMissing` checks for object references in `MLogging`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-785595bf-38a2-4b8b-901f-91185c695ad9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-785595bf-38a2-4b8b-901f-91185c695ad9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

